### PR TITLE
NetworkCompatibility

### DIFF
--- a/EnigmaticThunder/EnigmaticThunder.cs
+++ b/EnigmaticThunder/EnigmaticThunder.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx;
 using EnigmaticThunder.Modules;
 using EnigmaticThunder.Util;
+using EnigmaticThunder.Utils;
 using RoR2;
 using RoR2.ContentManagement;
 using RoR2.Skills;
@@ -81,6 +82,9 @@ namespace EnigmaticThunder
             SingletonHelper.Assign<EnigmaticThunderPlugin>(ref EnigmaticThunderPlugin.instance, this);
 
             GatherModules();
+
+            var networkCompatibilityHandler = new NetworkCompatibilityHandler();
+            networkCompatibilityHandler.BuildModList();
 
             RoR2.RoR2Application.isModded = true;
 

--- a/EnigmaticThunder/EnigmaticThunder.csproj
+++ b/EnigmaticThunder/EnigmaticThunder.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Util\Module.cs" />
     <Compile Include="Util\EnigmaticList.cs" />
     <Compile Include="Util\ErrorListener.cs" />
+    <Compile Include="Util\NetworkCompatibility.cs" />
     <Compile Include="Util\Reflection.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/EnigmaticThunder/Util/NetworkCompatibility.cs
+++ b/EnigmaticThunder/Util/NetworkCompatibility.cs
@@ -1,0 +1,157 @@
+﻿using RoR2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace EnigmaticThunder.Utils
+{
+
+    /// <summary>
+    /// Enum used for telling whether or not the mod should be needed by everyone in multiplayer games.
+    /// Also can specify if the mod does not work in multiplayer.
+    /// </summary>
+    public enum CompatibilityLevel
+    {
+        NoNeedForSync,
+        EveryoneMustHaveMod
+    }
+
+    /// <summary>
+    /// Enum used for telling whether or not the same mod version should be used by both the server and the clients.
+    /// This enum is only useful if CompatibilityLevel.EveryoneMustHaveMod was chosen.
+    /// </summary>
+    public enum VersionStrictness
+    {
+        DifferentModVersionsAreOk,
+        EveryoneNeedSameModVersion
+    }
+
+    /// <summary>
+    /// Attribute to have at the top of your BaseUnityPlugin class if
+    /// you want to specify if the mod should be installed by everyone in multiplayer games or not.
+    /// If the mod is required to be installed by everyone, you'll need to also specify if the same mod version should be used by everyone or not.
+    /// By default, it's supposed that everyone needs the mod and the same version.
+    /// e.g: [NetworkCompatibility(CompatibilityLevel.NoNeedForSync)]
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class NetworkCompatibility : Attribute
+    {
+
+        /// <summary>
+        /// Used for telling whether or not the mod should be needed by everyone in multiplayer games.
+        /// </summary>
+        public CompatibilityLevel CompatibilityLevel { get; internal set; }
+
+        /// <summary>
+        /// Enum used for telling whether or not the same mod version should be used by both the server and the clients.
+        /// This enum is only useful if CompatibilityLevel.EveryoneMustHaveMod was chosen.
+        /// </summary>
+        public VersionStrictness VersionStrictness { get; internal set; }
+
+        public NetworkCompatibility(
+            CompatibilityLevel compatibility = CompatibilityLevel.EveryoneMustHaveMod,
+            VersionStrictness versionStrictness = VersionStrictness.EveryoneNeedSameModVersion)
+        {
+            CompatibilityLevel = compatibility;
+            VersionStrictness = versionStrictness;
+        }
+    }
+
+    internal class NetworkCompatibilityHandler
+    {
+        internal const char ModGuidAndModVersionSeparator = ';';
+        internal readonly HashSet<string> ModList = new HashSet<string>();
+
+        internal void BuildModList()
+        {
+            EnigmaticThunderPlugin.start += ScanPluginsForNetworkCompat;
+        }
+
+        private void ScanPluginsForNetworkCompat(object _, EventArgs __)
+        {
+            foreach (var row in BepInEx.Bootstrap.Chainloader.PluginInfos)
+            {
+                var pluginInfo = row.Value;
+                try
+                {
+                    if (pluginInfo.Dependencies.All(dependency => dependency.DependencyGUID != EnigmaticThunderPlugin.guid))
+                    {
+                        continue;
+                    }
+
+                    var modGuid = pluginInfo.Metadata.GUID;
+                    var modVer = pluginInfo.Metadata.Version;
+                    
+                    TryGetNetworkCompatibility(pluginInfo.Instance.GetType(), out var networkCompatibility);
+                    if (networkCompatibility.CompatibilityLevel == CompatibilityLevel.EveryoneMustHaveMod)
+                    {
+                        ModList.Add(networkCompatibility.VersionStrictness == VersionStrictness.EveryoneNeedSameModVersion
+                            ? modGuid + ModGuidAndModVersionSeparator + modVer
+                            : modGuid);
+                    }
+                }
+                catch (Exception e)
+                {
+                    LogCore.logger.LogError($"Exception in ScanPluginsForNetworkCompat while scanning plugin {pluginInfo.Metadata.GUID}");
+                    LogCore.logger.LogError("EnigmaticThunder Failed to properly scan the assembly." + Environment.NewLine +
+                                          "Please make sure you are compiling against net standard 2.0 " +
+                                          "and not anything else when making a plugin for Risk of Rain 2 !" +
+                                          Environment.NewLine + e);
+                }
+            }
+
+            AddToNetworkModList();
+            EnigmaticThunderPlugin.start -= ScanPluginsForNetworkCompat;
+        }
+
+        private static void TryGetNetworkCompatibility(Type baseUnityPluginType, out NetworkCompatibility networkCompatibility)
+        {
+            networkCompatibility = new NetworkCompatibility();
+
+            foreach (var assemblyAttribute in baseUnityPluginType.Assembly.CustomAttributes)
+            {
+                if (ProcessAttribute(assemblyAttribute, networkCompatibility))
+                {
+                    return;
+                }
+            }
+
+            foreach (var attribute in baseUnityPluginType.CustomAttributes)
+            {
+                if (ProcessAttribute(attribute, networkCompatibility))
+                {
+                    return;
+                }
+            }
+        }
+
+        private static bool ProcessAttribute(CustomAttributeData attribute, in NetworkCompatibility networkCompatibility)
+        {
+            if (attribute.AttributeType == typeof(NetworkCompatibility))
+            {
+                networkCompatibility.CompatibilityLevel = (CompatibilityLevel)attribute.ConstructorArguments[0].Value;
+                networkCompatibility.VersionStrictness = (VersionStrictness)attribute.ConstructorArguments[1].Value;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private void AddToNetworkModList()
+        {
+            if (ModList.Count != 0)
+            {
+                var sortedModList = ModList.ToList();
+                sortedModList.Sort(StringComparer.InvariantCulture);
+                LogCore.logger.LogInfo("[NetworkCompatibility] Adding to the networkModList : ");
+                foreach (var mod in sortedModList)
+                {
+                    LogCore.logger.LogInfo(mod);
+                    NetworkModCompatibilityHelper.networkModList = NetworkModCompatibilityHelper.networkModList.Append(mod);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addressing #5.
Since EnigmaticThunder is still used and R2API no longer registers every mod to the network list, mods that only depend on EnigmaticThunder are not registered as required for everyone in multiplayer.

So, here is pretty much the same thing as in R2API. This will only register mod that depends on EngimaticThunder (have `[BepInDependency("com.EnigmaDev.EnigmaticThunder")]` attribute) and doesn't have `[NetworkCompatibility(CompatibilityLevel.NoNeedForSync)]`.

This is quite important because some mods (Goku for example) are not required for all in multiplayer atm, while they should.